### PR TITLE
fix: Update test expectation for API key description

### DIFF
--- a/__tests__/credentials/BunqApi.credentials.test.ts
+++ b/__tests__/credentials/BunqApi.credentials.test.ts
@@ -173,7 +173,7 @@ describe('BunqApi Credentials', () => {
 				(prop: INodeProperties) => prop.name === 'apiKey'
 			);
 			
-			expect(apiKeyProperty?.description).toBe('Your bunq API key');
+			expect(apiKeyProperty?.description).toBe('Your bunq API key - this is the only field you need to fill in');
 		});
 
 		it('should have helpful descriptions', () => {


### PR DESCRIPTION
This PR fixes the failing test by updating the expectation to match the actual API key description.

The test was expecting "Your bunq API key" but the actual description is "Your bunq API key - this is the only field you need to fill in" which is more helpful to users.

Fixes #7

Generated with [Claude Code](https://claude.ai/code)