### PR TITLE
fix: make bunqApi credential required to show credential selection

### DIFF
--- a/nodes/Bunq/Bunq.node.ts
+++ b/nodes/Bunq/Bunq.node.ts
@@ -46,7 +46,7 @@ export class Bunq implements INodeType {
 			},
 			{
 				name: 'bunqApi',
-				required: false,
+				required: true,
 			},
 		],
 		properties: [


### PR DESCRIPTION
Fixes #10 - Credentials selection dropdown not showing

The credentials dropdown wasn't appearing because both credential types were marked as `required: false`. By making `bunqApi` required, users will now see the credential selection dropdown in the n8n interface.

## Changes
- Updated `nodes/Bunq/Bunq.node.ts` to set `bunqApi` credential as `required: true`

## Testing
After this change, the credentials dropdown should appear above the Resource selector in the bunq node configuration.

Generated with [Claude Code](https://claude.ai/code)